### PR TITLE
Added the Ability to Restart the Server

### DIFF
--- a/minecraft.sh
+++ b/minecraft.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
+
 # Source function library
 ## CentOS/Fedora
 if [ -f /etc/rc.d/init.d/functions ]
@@ -15,16 +17,16 @@ fi
 #---------------------+
 #    Configuration    |
 #---------------------+
-SCRNNAME="minecraft"
-SERVICE="$SCRNNAME.jar"
-MCPATH="/home/mc/$SCRNNAME"
+SCRNNAME="mainMC"
+SERVICE="server.jar"
+MCPATH="/home/minecraft/$SCRNNAME"
 BACKUP_PATH="$MCPATH/backups"
 WORLDNAME="$(cat $MCPATH/server.properties | grep -E 'level-name' | sed -e s/.*level-name=//)"
 SERVERPORT="$(cat $MCPATH/server.properties | grep -E 'server-port' | sed -e s/.*server-port=//)"
-USER="root"
-CPU_COUNT="4"
-MINRAM="2G"
-MAXRAM="8G"
+USER="minecraft"
+CPU_COUNT="2"
+MINRAM="1G"
+MAXRAM="4G"
 INVOCATION="java -server -XX:UseSSE=4 -XX:+UseCMSCompactAtFullCollection -XX:ParallelGCThreads=$CPU_COUNT -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+DisableExplicitGC -XX:+CMSIncrementalMode -XX:+CMSIncrementalPacing -XX:+AggressiveOpts -Xms$MINRAM -Xmx$MAXRAM -XX:PermSize=128m -jar $SERVICE nogui"
 
 #---------------------+
@@ -36,6 +38,9 @@ STOP_WARNING_MAX="Server Restarting in 5 minutes..."
 STOP_WARNING_MID="Server Restarting in 1 minute..."
 STOP_WARNING_FINAL="Server shutting down in 10 seconds..."
 
+#---------------------+
+#      Utilities      |
+#---------------------+
 
 as_user() {
   ME="$(whoami)"
@@ -280,10 +285,6 @@ case $1 in
 	  mc_info
 	;;
 	serverCheck)
-	   if is_running; then
-	   	# Do nothing if server is running
-	   	true
-	   fi
 	   if ! is_running; then
 	   	mc_start
 	   fi

--- a/minecraft.sh
+++ b/minecraft.sh
@@ -17,16 +17,16 @@ fi
 #---------------------+
 #    Configuration    |
 #---------------------+
-SCRNNAME="mainMC"
-SERVICE="server.jar"
-MCPATH="/home/minecraft/$SCRNNAME"
+SCRNNAME="minecraft"
+SERVICE="$SCRNNAME.jar"
+MCPATH="/home/mc/$SCRNNAME"
 BACKUP_PATH="$MCPATH/backups"
 WORLDNAME="$(cat $MCPATH/server.properties | grep -E 'level-name' | sed -e s/.*level-name=//)"
 SERVERPORT="$(cat $MCPATH/server.properties | grep -E 'server-port' | sed -e s/.*server-port=//)"
-USER="minecraft"
-CPU_COUNT="2"
-MINRAM="1G"
-MAXRAM="4G"
+USER="root"
+CPU_COUNT="4"
+MINRAM="2G"
+MAXRAM="8G"
 INVOCATION="java -server -XX:UseSSE=4 -XX:+UseCMSCompactAtFullCollection -XX:ParallelGCThreads=$CPU_COUNT -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+DisableExplicitGC -XX:+CMSIncrementalMode -XX:+CMSIncrementalPacing -XX:+AggressiveOpts -Xms$MINRAM -Xmx$MAXRAM -XX:PermSize=128m -jar $SERVICE nogui"
 
 #---------------------+

--- a/minecraft.sh
+++ b/minecraft.sh
@@ -36,9 +36,6 @@ STOP_WARNING_MAX="Server Restarting in 5 minutes..."
 STOP_WARNING_MID="Server Restarting in 1 minute..."
 STOP_WARNING_FINAL="Server shutting down in 10 seconds..."
 
-#---------------------+
-#      Utilities      |
-#---------------------+
 
 as_user() {
   ME="$(whoami)"
@@ -73,11 +70,13 @@ mc_save() {
   if is_running; then
     echo " * Saving map named \"$WORLDNAME\" to disk..."
     mc_alert "$SAVE_START"
+	mc_run "say Beginning autosave..."
     mc_run "save-off"
     mc_run "save-all"
     sync ; sleep 10
     mc_alert "$SAVE_END"
     mc_run "save-on"
+	mc_run "say Autosave complete."
     echo " * World save complete"
   else
     echo " * [ERROR] $SCRNNAME was not running, cannot save world"
@@ -259,9 +258,17 @@ case $1 in
 	  mc_stop
 	;;
 	restart)
+	  echo " * Restart command issued"
+	  echo " * Issuing 5 minute warning to users..."
+	  mc_run "say Server will restart in 5 minutes!"
+	  sleep 240
+	  echo " * Issuing 1 minute warning to users..."
+	  mc_run "say Server will restart in 1 minute!"
+	  sleep 60
+  	  echo " * Server will begin restarting now..."
+	  mc_run "say Server will restart now!"
 	  mc_stop
 	  mc_start
-	  mc_console
 	;;
 	save)
 	  mc_save
@@ -271,6 +278,15 @@ case $1 in
 	;;
 	info)
 	  mc_info
+	;;
+	serverCheck)
+	   if is_running; then
+	   	# Do nothing if server is running
+	   	true
+	   fi
+	   if ! is_running; then
+	   	mc_start
+	   fi
 	;;
 	run)
 	  echo " * Ran \"$2\" on $SCRNNAME"


### PR DESCRIPTION
This is a fork of the MinecraftStartupScript made by ForsakenDev. This change allows your server to automatically restart in the event of a crash. To enable this functionality, add a line you your crontab to automatically call this this script and pass in the "serverCheck" argument (set this to run every 2 minutes or so). The script will check if the server is down and and will automatically start it back up.

NOTE: If you wish to keep your server down for a long period of time (for example, when updating your Minecraft server version) you must comment out the serverCheck line in your crontab otherwise the script will start your server back up while you are working on it.